### PR TITLE
APIトークンを直接打たないでファイルから読み込む方法に変えました。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .python-version
 __pycache__/
+APITOKEN.py

--- a/slackbot_settings.py
+++ b/slackbot_settings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
- 
-API_TOKEN = ""
+import APITOKEN 
+
+API_TOKEN = APITOKEN.APIAPI
 PLUGINS = [
     'plugins',
 ]


### PR DESCRIPTION
直接打つとgitにアップできないし、かといってgitignoreに入力するのはなんかあれだしで
APIトークンだけを書いたファイルを用意してそれをgitignoreに追加して、
そこからAPIトークンの文字列を読み込むことにしました。
